### PR TITLE
Use official docs URL in description

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -38,7 +38,7 @@ Description: General purpose TIFF file I/O for R users.
     write TIFF files than can be correctly read by 'ImageJ'
     <https://imagej.nih.gov/ij/>.  Also supports text image I/O.
 License: GPL-3
-URL: https://ropensci.github.io/ijtiff,
+URL: https://docs.ropensci.org/ijtiff,
     https://www.github.com/ropensci/ijtiff
 BugReports: https://www.github.com/ropensci/ijtiff/issues
 Depends: 


### PR DESCRIPTION
Hello from rOpenSci!

The official [rOpenSci docs server](https://docs.ropensci.org) which we [announced](https://ropensci.org/technotes/2019/06/07/ropensci-docs/) in June is fully ready for production now. Our server automatically builds and hosts pkgdown sites for all ropensci packages.

 - Official documentation URL: https://docs.ropensci.org/ijtiff
 - Website build logs: https://dev.ropensci.org/job/ijtiff (click "last build" -> "console output")

If all seems good, we strongly suggest to add the URL to the package DESCRIPTION file and include this in the next CRAN update. This has two major benefits:

  - Pkgdown does automatic [cross-linking](https://pkgdown.r-lib.org/dev/articles/linking.html) to other pkgdown sites that can be found via CRAN. This means that if another package refers to your package in an example or vignette, their pkgdown site automatically hyperlinks those functions to your pkgdown site (if your pkgdown URL has been published on CRAN!)
  - Because all our documentation is hosted under `docs.ropensci.org` this will accumulate a higher pagerank than when a site are hosted on various custom domains. This should make it easier to find these documentation sites on Google and other search engines.

We hope that this service will make it easy to maintain high quality and visible documentation for your packages! If something is unclear or not working, feel free to ask questions here or on slack.

## FAQ

### 1. What do I need to do to maintain documentation at docs.ropensci.org?

Absolutely nothing, everything is done automatically.

### 2. How can I customize my docs.ropensci.org site?

You can use all standard pkgdown options in your `pkgdown.yml` file, except for the template (we use the [rotemplate pkgdown theme](https://github.com/ropensci/rotemplate) to render). 

### 3. Can I help to improve the template?

Of course! You can send pull requests to [ropensci/rotemplate](https://github.com/ropensci/rotemplate).

### 4. Why are the images from the readme.md not showing in my pkgdown site?

pkgdown [only supports local images](https://github.com/ropensci/rotemplate/issues/19) in a few locations since only a few locations also work with CRAN's rendering of readme's.  The recommended path for static images is `man/figures`.

### 5. I already had a site. How to create a redirect from my old pkgdown site?
  
Simply push an `index.html` file that redirects to the new site, see for example [here](https://github.com/ropensci/magick/blob/gh-pages/index.html).

