### PR TITLE
Fixes for 32-bit Windows (fixes #11)

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -15,12 +15,12 @@ cache:
 
 # Adapt as necessary starting from here
 
-platform: x64
-
 environment:
-  R_VERSION: release
   BIOC_USE_DEVEL: FALSE
   R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+  matrix:
+    - R_VERSION: 3.6.3
+    - R_VERSION: release
 
 build_script:
   - travis-tool.sh install_bioc_deps

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,7 +1,6 @@
-LIB_TIFF ?= ../windows/libtiff-4.0.9
-PKG_CPPFLAGS = -I$(LIB_TIFF)/include
-PKG_LIBS = -L$(LIB_TIFF)/lib${R_ARCH} -ltiff -ljpeg -llzma -lz
-
+RWINLIB = ../windows/libtiff-4.1.0/mingw$(WIN)
+PKG_CPPFLAGS = -I$(RWINLIB)/include
+PKG_LIBS = -L$(RWINLIB)/lib -ltiff -ljpeg -lz
 
 all: clean winlibs
 

--- a/tests/testthat/test-as_EBImage-examples.R
+++ b/tests/testthat/test-as_EBImage-examples.R
@@ -1,5 +1,4 @@
 test_that("`as_EBImage()` works", {
-  skip_if(win32bit())
   skip_if_not_installed("EBImage")
   img <- read_tif(system.file("img", "Rlogo.tif", package = "ijtiff"))
   expect_equal(dim(img), c(76, 100, 4, 1))

--- a/tests/testthat/test-count_imgs-examples.R
+++ b/tests/testthat/test-count_imgs-examples.R
@@ -1,5 +1,4 @@
 test_that("`count_frames()` works", {
-  skip_if(win32bit())
   expect_equal(
     count_frames(system.file("img", "Rlogo.tif", package = "ijtiff")),
     structure(1, n_dirs = 1)

--- a/tests/testthat/test-graphics.R
+++ b/tests/testthat/test-graphics.R
@@ -1,5 +1,4 @@
 test_that("display works", {
-  skip_if(win32bit())
   skip_if_not_installed("vdiffr")
   img <- read_tif(system.file("img", "Rlogo.tif", package = "ijtiff"))
   vdiffr::expect_doppelganger("raster R logo", display(img, method = "r"))

--- a/tests/testthat/test-io.R
+++ b/tests/testthat/test-io.R
@@ -1,5 +1,4 @@
 test_that("Package 2-channel example I/O works", {
-  skip_if(win32bit())
   set.seed(1)
   img0 <- read_tif(test_path("testthat-figs", "2ch_ij.tif"))
   expect_equal(dim(img0), c(15, 6, 2, 5))
@@ -51,13 +50,11 @@ test_that("Package 2-channel example I/O works", {
 })
 
 test_that("Package RGB I/O works", {
-  skip_if(win32bit())
   img <- read_tif(system.file("img", "Rlogo.tif", package = "ijtiff"))
   expect_equal(dim(img), c(76, 100, 4, 1))
 })
 
 test_that("8-bit unsigned integer TIFF I/O works", {
-  skip_if(win32bit())
   set.seed(2)
   v2345 <- 2:5
   a2345 <- array(sample.int(prod(v2345)), dim = v2345)
@@ -70,7 +67,6 @@ test_that("8-bit unsigned integer TIFF I/O works", {
 })
 
 test_that("16-bit unsigned integer TIFF I/O works", {
-  skip_if(win32bit())
   set.seed(3)
   v6789 <- 6:9
   a6789 <- array(sample.int(prod(v6789)), dim = v6789)
@@ -83,7 +79,6 @@ test_that("16-bit unsigned integer TIFF I/O works", {
 })
 
 test_that("32-bit unsigned integer TIFF I/O works", {
-  skip_if(win32bit())
   set.seed(4)
   v1m <- c(20, 50, 10, 100)
   a1m <- array(sample.int(2^32 - 1, prod(v1m)), dim = v1m)
@@ -96,7 +91,6 @@ test_that("32-bit unsigned integer TIFF I/O works", {
 })
 
 test_that("Float (real-numbered) TIFF I/O works", {
-  skip_if(win32bit())
   set.seed(5)
   v2345 <- 2:5
   a2345 <- array(sample.int(prod(v2345)), dim = v2345) + 0.5
@@ -118,7 +112,6 @@ test_that("Float (real-numbered) TIFF I/O works", {
 })
 
 test_that("Negative-numbered TIFF I/O works", {
-  skip_if(win32bit())
   v2345 <- 2:5
   a2345 <- array(sample.int(prod(v2345)), dim = v2345)
   a2345[1] <- -1
@@ -132,7 +125,6 @@ test_that("Negative-numbered TIFF I/O works", {
 })
 
 test_that("List returning works", {
-  skip_if(win32bit())
   skip_if_not_installed("tiff")
   img1 <- matrix(0.5, nrow = 2, ncol = 2)
   img2 <- matrix(0.7, nrow = 3, ncol = 7)
@@ -153,7 +145,6 @@ test_that("List returning works", {
 })
 
 test_that("TIFFErrorHandler_ works", {
-  skip_if(win32bit())
   tmptxt <- tempfile(fileext = ".txt") %>%
     stringr::str_replace_all(stringr::coll("\\"), "/")
   writeLines(c("a", "b"), tmptxt)
@@ -161,7 +152,6 @@ test_that("TIFFErrorHandler_ works", {
 })
 
 test_that("write_tif() errors correctly", {
-  skip_if(win32bit())
   aaaa <- array(0, dim = rep(4, 4))
   expect_error(tif_write(aaaa, "path/"), "path.+cannot end with.+/")
   expect_error(
@@ -279,7 +269,6 @@ test_that("write_tif() errors correctly", {
 })
 
 test_that("text-image-io works", {
-  skip_if(win32bit())
   mm <- matrix(1:60, nrow = 4)
   dim(mm) %<>% c(1, 1)
   tmpfl <- tempfile() %>%
@@ -351,7 +340,6 @@ test_that("text-image-io works", {
 })
 
 test_that("reading certain frames works", {
-  skip_if(win32bit())
   path <- test_path("testthat-figs", "2ch_ij.tif")
   img <- read_tif(path, "A")
   img12 <- read_tif(path, frames = 1:2)
@@ -406,7 +394,6 @@ test_that("reading certain frames works", {
 })
 
 test_that("Reading Mathieu's files works", {
-  skip_if(win32bit())
   hs <- read_tif(test_path("testthat-figs", "HyperStack.tif"))
   expect_equal(dim(hs), c(300, 400, 6, 12))
   expect_equal(dim(attr(hs, "color_map")), c(256, 3))

--- a/tests/testthat/test-read_tags-examples.R
+++ b/tests/testthat/test-read_tags-examples.R
@@ -1,5 +1,4 @@
 test_that("`read_tags()` works", {
-  skip_if(win32bit())
   path <- system.file("img", "Rlogo.tif", package = "ijtiff")
   tags <- read_tags(path)
   ans <- list(frame1 = list(

--- a/tools/winlibs.R
+++ b/tools/winlibs.R
@@ -1,7 +1,7 @@
 # Build against libtiff compiled with Rtools
-if (!file.exists("../windows/libtiff-4.0.9/include/tiff.h")) {
+if (!file.exists("../windows/libtiff-4.1.0/mingw64/include/tiff.h")) {
   if(getRversion() < "3.3.0") setInternet2()
-  download.file("https://github.com/rwinlib/libtiff/archive/v4.0.9.zip",
+  download.file("https://github.com/rwinlib/libtiff/archive/v4.1.0.zip",
                 "lib.zip", quiet = TRUE)
   dir.create("../windows", showWarnings = FALSE)
   unzip("lib.zip", exdir = "../windows")


### PR DESCRIPTION
I finally understand the problem now. Previously we used the same libtiff header files 32-bit and 64-bit which is almost always fine, but apparently in the case of libtiff those are different.

So I did a fresh build of libtiff with separate headers for mingw32 and mingw64.

I think we're getting closer to a proper solution. Winbuilder seems unavailable right now so I can't really test that, but I'm sure we'll be able to figure that out as well. At least this now passes in 32 and 64 bit on both the old and new toolchain 🎉 