### PR TITLE
Use libtiff from Rtools if found

### DIFF
--- a/configure.win
+++ b/configure.win
@@ -1,2 +1,0 @@
-#!/usr/bin/env sh
-"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" tools/config.R configure "$@"

--- a/src/Makevars.win
+++ b/src/Makevars.win
@@ -1,11 +1,22 @@
+PKG_CONFIG_NAME = libtiff-4
+PKG_CONFIG ?= $(BINPREF)pkg-config
+PKG_LIBS := $(shell $(PKG_CONFIG) --libs $(PKG_CONFIG_NAME))
+
+ifneq ($(PKG_LIBS),)
+$(info using $(PKG_CONFIG_NAME) from Rtools)
+PKG_CPPFLAGS := $(shell $(PKG_CONFIG) --cflags $(PKG_CONFIG_NAME))
+else
 MSYSTEM = mingw$(WIN)
 RWINLIB = ../windows/libtiff
 PKG_CPPFLAGS = -I$(RWINLIB)/$(MSYSTEM)/include -I$(RWINLIB)/include
 PKG_LIBS = -L$(RWINLIB)/$(MSYSTEM)/lib -L$(RWINLIB)/lib -ltiff -ljpeg -lz
+endif
 
-all: clean winlibs
+all: $(SHLIB)
 
-winlibs:
+$(OBJECTS): $(RWINLIB)
+
+$(RWINLIB):
 	"${R_HOME}/bin${R_ARCH_BIN}/Rscript.exe" "../tools/winlibs.R"
 
 clean:


### PR DESCRIPTION
New CRAN policy is to use the library from Rtools if it is available.